### PR TITLE
enhance CLI single test

### DIFF
--- a/--verbose=1
+++ b/--verbose=1
@@ -1,0 +1,13 @@
+Generated filenames: source='test/test_asserts.c', object='build/tmp/st_test_asserts.c_5897.o', executable='build/tmp/st_test_asserts.c_5897.exe'
+Generated filenames: source='src/sigtest.c', object='build/tmp/st_sigtest.c_5897.o', executable='(null)'
+Compiling: command='gcc -c test/test_asserts.c -Iinclude -DSIGTEST_TEST -o build/tmp/st_test_asserts.c_5897.o'
+Compiling: command='gcc -c src/sigtest.c -Iinclude -DSIGTEST_TEST -o build/tmp/st_sigtest.c_5897.o'
+Compiled: source=`test/test_asserts.c`, object=`build/tmp/st_test_asserts.c_5897.o`, executable=`build/tmp/st_test_asserts.c_5897.exe`
+Linking: gcc build/tmp/st_test_asserts.c_5897.o build/tmp/st_sigtest.c_5897.o  -o build/tmp/st_test_asserts.c_5897.exe
+Linked: object=`build/tmp/st_test_asserts.c_5897.o`, executable=`build/tmp/st_test_asserts.c_5897.exe`
+Running: build/tmp/st_test_asserts.c_5897.exe
+[2025-05-22  12:03:22]   Test Set:                    asserts_set
+=================================================================
+Tests run: 13, Passed: 12, Failed: 0, Skipped: 1
+Total test sets registered: 1
+Cleaned: build/tmp/st_test_asserts.c_5897.o, build/tmp/st_test_asserts.c_5897.exe

--- a/include/sigtest.h
+++ b/include/sigtest.h
@@ -42,15 +42,15 @@ typedef void (*CleanupFunc)(void);	 // Test set cleanup function pointer
 // typedef void (*OutputFunc)(const TestSet, const TestCase, const object); // Output formatting function
 typedef void (*SetOp)(const TestSet, object); // Test set operation function pointer
 
-// Output log levels
+// Output debug levels
 typedef enum
 {
-	LOG_DEBUG,	 // Debug level logging
-	LOG_INFO,	 // Info level logging
-	LOG_WARNING, // Warning level logging
-	LOG_ERROR,	 // Error (non-fatal) level logging
-	LOG_FATAL,	 // Fatal error level logging
-} LogLevel;
+	DBG_DEBUG,	 // Debug level logging
+	DBG_INFO,	 // Info level logging
+	DBG_WARNING, // Warning level logging
+	DBG_ERROR,	 // Error (non-fatal) level logging
+	DBG_FATAL,	 // Fatal error level logging
+} DebugLevel;
 
 extern TestSet test_sets; // Global test set registry
 
@@ -183,8 +183,8 @@ typedef struct sigtest_case_s
  */
 typedef struct sigtest_logger_s
 {
-	void (*log)(const char *, ...);				  /* Logging function pointer */
-	void (*debug)(LogLevel, const char *, ...); /* Debug logging function pointer */
+	void (*log)(const char *, ...);					 /* Logging function pointer */
+	void (*debug)(DebugLevel, const char *, ...); /* Debug logging function pointer */
 } sigtest_logger_s;
 
 /**

--- a/logs/build_all.log
+++ b/logs/build_all.log
@@ -1,0 +1,6 @@
+find build -type f -delete
+find bin -type f -delete
+gcc -Wall -g -fPIC -Iinclude -DSIGTEST_TEST -c src/sigtest.c -o build/sigtest.o
+gcc  build/sigtest.o -o bin/lib/libsigtest.so -shared
+gcc -Wall -g -fPIC -Iinclude -c src/sigtest_cli.c -o build/sigtest_cli.o
+gcc  build/sigtest_cli.o -o bin/sigtest -g -Lbin/lib -lsigtest -Wl,-rpath,bin/lib

--- a/logs/run_test_asserts.log
+++ b/logs/run_test_asserts.log
@@ -1,4 +1,13 @@
-[2025-05-21  08:06:16]   Test Set:                    asserts_set
+Generated filenames: source='test/test_asserts.c', object='build/tmp/st_test_asserts.c_5971.o', executable='build/tmp/st_test_asserts.c_5971.exe'
+Generated filenames: source='src/sigtest.c', object='build/tmp/st_sigtest.c_5971.o', executable='(null)'
+Compiling: command='gcc -c test/test_asserts.c -Iinclude -DSIGTEST_TEST -o build/tmp/st_test_asserts.c_5971.o'
+Compiling: command='gcc -c src/sigtest.c -Iinclude -DSIGTEST_TEST -o build/tmp/st_sigtest.c_5971.o'
+Compiled: source=`test/test_asserts.c`, object=`build/tmp/st_test_asserts.c_5971.o`, executable=`build/tmp/st_test_asserts.c_5971.exe`
+Linking: gcc build/tmp/st_test_asserts.c_5971.o build/tmp/st_sigtest.c_5971.o  -o build/tmp/st_test_asserts.c_5971.exe
+Linked: object=`build/tmp/st_test_asserts.c_5971.o`, executable=`build/tmp/st_test_asserts.c_5971.exe`
+Running: build/tmp/st_test_asserts.c_5971.exe
+[2025-05-22  12:05:52]   Test Set:                    asserts_set
 =================================================================
 Tests run: 13, Passed: 12, Failed: 0, Skipped: 1
 Total test sets registered: 1
+Cleaned: build/tmp/st_test_asserts.c_5971.o, build/tmp/st_test_asserts.c_5971.exe

--- a/logs/test_asserts.log
+++ b/logs/test_asserts.log
@@ -1,18 +1,18 @@
 Test Source: test/test_asserts.c
-[1] asserts_set              :  13 :         2025-05-21  08:06:16
+[1] asserts_set              :  13 :         2025-05-22  12:05:52
 =================================================================
-Running: Assert Is Null                          1.744 us  [PASS]
-Running: Assert Is Not Null                      0.797 us  [PASS]
-Running: Assert Int Not Equal                    0.536 us  [PASS]
-Running: Assert Float Not Equal                  0.234 us  [PASS]
-Running: Assert Strings Not Comparable           2.082 us  [PASS]
-Running: Assert Float Within                     0.319 us  [PASS]
-Running: Assert Float Not Within                 3.006 us  [PASS]
-Running: Assert String Equal                     1.741 us  [PASS]
-Running: Assert String Not Equal                 7.119 us  [PASS]
-Running: Assert String Case Insensitive          0.332 us  [PASS]
-Running: Assert String Case Sensitive            2.636 us  [PASS]
-Running: Assert Fail Test Case                   0.812 us  [PASS]
-Running: Assert Skip Test Case                   0.429 us  [SKIP]
+Running: Assert Is Null                          0.816 us  [PASS]
+Running: Assert Is Not Null                      0.783 us  [PASS]
+Running: Assert Int Not Equal                    0.502 us  [PASS]
+Running: Assert Float Not Equal                  0.336 us  [PASS]
+Running: Assert Strings Not Comparable           1.044 us  [PASS]
+Running: Assert Float Within                     0.367 us  [PASS]
+Running: Assert Float Not Within                 2.354 us  [PASS]
+Running: Assert String Equal                     0.951 us  [PASS]
+Running: Assert String Not Equal                 4.257 us  [PASS]
+Running: Assert String Case Insensitive          0.391 us  [PASS]
+Running: Assert String Case Sensitive            1.911 us  [PASS]
+Running: Assert Fail Test Case                   0.708 us  [PASS]
+Running: Assert Skip Test Case                   0.481 us  [SKIP]
 =================================================================
 [1]     TESTS= 13        PASS= 12        FAIL=  0        SKIP=  1

--- a/src/sigtest.c
+++ b/src/sigtest.c
@@ -36,15 +36,17 @@ const char *TEST_STATES[] = {
 	 "PASS",
 	 "FAIL",
 	 "SKIP",
-	 NULL};
+	 NULL,
+};
 // For dynamic log level annotation
-const char *LOG_LEVELS[] = {
+static const char *DBG_LEVELS[] = {
 	 "DEBUG",
 	 "INFO",
 	 "WARNING",
 	 "ERROR",
 	 "FATAL",
-	 NULL};
+	 NULL,
+};
 //	system clock structures
 #define SYS_CLOCK SYS_clock_gettime
 #define CLOCK_MONOTONIC 1
@@ -58,7 +60,7 @@ double get_elapsed_ms(ts_time *start, ts_time *end)
 }
 //	internal logger declarations
 static void log_message(const char *, ...);
-static void log_debug(LogLevel, const char *, ...);
+static void log_debug(DebugLevel, const char *, ...);
 // hooks registry
 static HookRegistry *hook_registry = NULL;
 
@@ -949,12 +951,12 @@ static void default_on_test_result(const TestSet set, const TestCase tc, object 
 
 	if (ctx->verbose && tc->test_result.message)
 	{
-		LogLevel level = (tc->test_result.state == PASS) ? LOG_INFO : LOG_DEBUG;
+		DebugLevel level = (tc->test_result.state == PASS) ? DBG_INFO : DBG_DEBUG;
 		set->logger->debug(level, "\tmessage= %s\n", tc->test_result.message ? tc->test_result.message : "NULL");
 	}
 	if (ctx->verbose)
 	{
-		set->logger->debug(LOG_DEBUG, "\tstart= %ld.%04ld", ctx->start.tv_sec, ctx->start.tv_nsec);
+		set->logger->debug(DBG_DEBUG, "\tstart= %ld.%04ld", ctx->start.tv_sec, ctx->start.tv_nsec);
 		set->logger->log("\tend=   %ld.%04ld\n", ctx->end.tv_sec, ctx->end.tv_nsec);
 	}
 }
@@ -1258,13 +1260,13 @@ static void log_message(const char *fmt, ...)
 
 	va_end(args);
 }
-static void log_debug(LogLevel level, const char *fmt, ...)
+static void log_debug(DebugLevel level, const char *fmt, ...)
 {
 	va_list args;
 	va_start(args, fmt);
 
 	FILE *stream = current_set && current_set->log_stream ? current_set->log_stream : stdout;
-	fprintf(stream, "[%s] ", LOG_LEVELS[level]);
+	fprintf(stream, "[%s] ", DBG_LEVELS[level]);
 	vfprintf(stream, fmt, args);
 	fflush(stream);
 

--- a/src/sigtest_cli.h
+++ b/src/sigtest_cli.h
@@ -10,12 +10,15 @@
 #include "sigtest.h"
 #include <stdio.h>
 
-// CLI specific declarations
-void cleanup_test_runner(void);
-void fwritef(FILE *, const char *, ...);
+#define MAX_TEMPLATE_LEN 64
 
-// Initialize CLI hooks
-void init_cli_hooks(SigtestHooks *, FILE *);
+// Output log levels
+typedef enum
+{
+   LOG_NONE,    // No logging
+   LOG_MINIMAL, // Minimal logging
+   LOG_VERBOSE, // Verbose logging
+} LogLevel;
 
 // CLI state structure
 typedef struct
@@ -24,9 +27,9 @@ typedef struct
    {
       START,
       TEST_SRC,
-      // FORMAT,
       DONE,
-      ERROR
+      ERROR,
+      IGNORE,
    } state;
    enum
    {
@@ -36,9 +39,18 @@ typedef struct
    } mode;
    const char *test_src;
    int no_clean;
-   int verbose;
+   LogLevel log_level;
+   DebugLevel debug_level;
 } CliState;
 
-#define MAX_TEMPLATE_LEN 64
+/**
+ * @brief Debug logging function
+ * @param stream :the output stream to write to
+ * @param log_level :the log level
+ * @param debug_level :the debug level
+ * @param fmt :the format message to display
+ * @param ... :the variable arguments for the format message
+ */
+void fdebugf(FILE *, LogLevel, DebugLevel, const char *, ...);
 
 #endif // SIGTEST_CLI_H


### PR DESCRIPTION
- updated logging to create a more robust `fdebugf` mechanism with:
  - **`LogLevel`** - `LOG_NONE`, `LOG_MINIMAL`, `LOG_VERBOSE`
  - **`DebugLevel`** (from `sigtest.c`) - `DBG_DEBUG`, `DBG_INFO`, `DBG_WARNING`, `DBG_ERROR`, `DBG_FATAL`
- decoupled hook directories from build process
- **CL**: more robust `--verbose` logging flexibility
  - `-v` & `--verbose` set `LOG_VERBOSE`
  - `--verbose=[0-2]` to set a specific level
- **CL**: added `--debug=[0-4]`